### PR TITLE
v1.2.

### DIFF
--- a/src/main/java/com/iffomko/apsofttesttask/controllers/exceptionHandlers/DefaultResponseEntityExceptionHandler.java
+++ b/src/main/java/com/iffomko/apsofttesttask/controllers/exceptionHandlers/DefaultResponseEntityExceptionHandler.java
@@ -130,7 +130,7 @@ public class DefaultResponseEntityExceptionHandler extends ResponseEntityExcepti
             HttpStatusCode status,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format("{0}, variable name: {1}", ex.getMessage(), ex.getVariableName()));
+        log.debug(String.format("%s, variable name: %s", ex.getMessage(), ex.getVariableName()));
         return ResponseEntity.status(status.value()).body(new MissingPathVariableResponse(
                 ResponseEntityExceptionHandlerMessages.MISSING_PATH_VARIABLE.getMessage(),
                 ResponseEntityExceptionHandlerCodes.MISSING_PATH_VARIABLE.name(),
@@ -155,8 +155,8 @@ public class DefaultResponseEntityExceptionHandler extends ResponseEntityExcepti
             HttpStatusCode status,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format(
-                "{0}, type: {1}, name: {2}",
+        log.debug(String.format(
+                "%s, type: %s, name: %s",
                 ex.getMessage(),
                 ex.getParameterType(),
                 ex.getParameterName()
@@ -187,8 +187,8 @@ public class DefaultResponseEntityExceptionHandler extends ResponseEntityExcepti
             HttpStatusCode status,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format(
-                "{0}, part-name: {1}",
+        log.debug(String.format(
+                "%s, part-name: %s",
                 ex.getMessage(),
                 ex.getRequestPartName()
         ));
@@ -241,8 +241,8 @@ public class DefaultResponseEntityExceptionHandler extends ResponseEntityExcepti
             HttpStatusCode status,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format(
-                "{0}, parameter-name: {1}",
+        log.debug(String.format(
+                "%s, parameter-name: %s",
                 ex.getMessage(),
                 ex.getParameter().getParameterName()
         ));
@@ -270,8 +270,8 @@ public class DefaultResponseEntityExceptionHandler extends ResponseEntityExcepti
             HttpStatusCode status,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format(
-                "{0}, parameter-name: {1}",
+        log.debug(String.format(
+                "%s, parameter-name: %s",
                 ex.getMessage(),
                 ex.getRequestURL()
         ));

--- a/src/main/java/com/iffomko/apsofttesttask/controllers/exceptionHandlers/OtherResponseEntityExceptionHandler.java
+++ b/src/main/java/com/iffomko/apsofttesttask/controllers/exceptionHandlers/OtherResponseEntityExceptionHandler.java
@@ -32,8 +32,8 @@ public class OtherResponseEntityExceptionHandler {
             SizeLimitExceededException ex,
             WebRequest request
     ) {
-        log.debug(MessageFormat.format(
-                "{0}, actual size: {1}, permitted size: {2}",
+        log.debug(String.format(
+                "%s, actual size: %s, permitted size: %s",
                 ResponseEntityExceptionHandlerMessages.SIZE_LIMIT_EXCEEDED_EXCEPTION.getMessage(),
                 ex.getActualSize(),
                 ex.getPermittedSize()

--- a/src/main/java/com/iffomko/apsofttesttask/services/FilesLoaderService.java
+++ b/src/main/java/com/iffomko/apsofttesttask/services/FilesLoaderService.java
@@ -17,7 +17,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -54,6 +53,22 @@ public class FilesLoaderService {
     }
 
     /**
+     * Переводит стек вызовов в строковое представление
+     * @param stackTraceElements сам стек вызовов
+     * @return строковое представление
+     */
+    private String stackTraceElementsToString(StackTraceElement[] stackTraceElements) {
+        StringBuilder stringView = new StringBuilder();
+
+        for (StackTraceElement stackTraceElement : stackTraceElements) {
+            stringView.append(stackTraceElement);
+            stringView.append("\r\n");
+        }
+
+        return stringView.toString();
+    }
+
+    /**
      * <p>
      *     Парсит текстовый файл из формата, где символ '#' указывает на начало раздела,
      *     а количество повторений этого символа для раздела указывает на его вложенность,
@@ -65,8 +80,8 @@ public class FilesLoaderService {
     public ResponseEntity<?> parseFile(MultipartFile multipartFile) {
         try {
             if (!(Objects.equals(multipartFile.getContentType(), MediaType.TEXT_PLAIN_VALUE))) {
-                log.error(MessageFormat.format(
-                        "Invalid content-type in the request: {0}",
+                log.error(String.format(
+                        "Invalid content-type in the request: %s",
                         multipartFile.getContentType()
                 ));
                 return ResponseEntity.badRequest().body(new FilesLoaderErrorResponse(
@@ -84,16 +99,16 @@ public class FilesLoaderService {
                     resultText
             ));
         } catch (UnsupportedEncodingException e) {
-            log.error(MessageFormat.format("Unsupported encoding exception: {0}", e.getMessage()));
+            log.error(String.format("Unsupported encoding exception: %s", e.getMessage()));
             return ResponseEntity.badRequest().body(new FilesLoaderErrorResponse(
                     FileLoaderResponseMessages.INCORRECT_ENCODING.getMessage(),
                     FileLoaderResponseCodes.INCORRECT_ENCODING.name()
             ));
         } catch (Exception e) {
-            log.error(MessageFormat.format(
-                    "Internal server error:\r\nmessage: {0}\r\nstack trace: {1}",
+            log.error(String.format(
+                    "Internal server error:\r\nmessage: %s\r\nstack trace: %s",
                     e.getMessage(),
-                    e.getStackTrace()
+                    stackTraceElementsToString(e.getStackTrace())
             ));
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new FilesLoaderErrorResponse(
                     FileLoaderResponseMessages.INTERNAL_SERVER_ERROR.getMessage(),

--- a/src/main/java/com/iffomko/apsofttesttask/services/parser/IntoHtmlFileParser.java
+++ b/src/main/java/com/iffomko/apsofttesttask/services/parser/IntoHtmlFileParser.java
@@ -3,7 +3,6 @@ package com.iffomko.apsofttesttask.services.parser;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,8 +26,8 @@ public class IntoHtmlFileParser implements IFileParser {
      */
     private record Section(String data, String id) {
         public String parse() {
-            return MessageFormat.format(
-                    "<div><a class=\"section_link\" href=\"#{0}\">{1}</a></div>",
+            return String.format(
+                    "<div><a class=\"section_link\" href=\"#%s\">%s</a></div>",
                     id, data);
         }
     }
@@ -118,14 +117,14 @@ public class IntoHtmlFileParser implements IFileParser {
     private record Paragraph(String data, String id) {
         public String parse() {
             if (id == null) {
-                return MessageFormat.format(
-                        "<div>{0}</div>",
+                return String.format(
+                        "<div>%s</div>",
                         data
                 );
             }
 
-            return MessageFormat.format(
-                    "<div><a name=\"{0}\">{1}</a></div>",
+            return String.format(
+                    "<div><a name=\"%s\">%s</a></div>",
                     id,
                     data
             );
@@ -240,7 +239,7 @@ public class IntoHtmlFileParser implements IFileParser {
             String depth = printDepth(currentDepth);
             String sectionId = String.format("%d_%d", sectionIndex, Math.abs(sectionTitle.hashCode()));
 
-            parsedSections.add(new Section(MessageFormat.format("{0} {1}", depth, sectionName), sectionId));
+            parsedSections.add(new Section(String.format("%s %s", depth, sectionName), sectionId));
 
             lines.add(sectionIndex, new Paragraph(lines.get(sectionIndex), sectionId).parse());
             lines.remove(sectionIndex + 1);

--- a/src/test/java/com/iffomko/apsofttesttask/FilesLoaderControllerTests.java
+++ b/src/test/java/com/iffomko/apsofttesttask/FilesLoaderControllerTests.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -44,10 +45,10 @@ public class FilesLoaderControllerTests {
         ResponseEntity<?> actualResult = filesLoaderController.handlePostFileParser(multipartFile);
         FilesLoaderErrorResponse body = (FilesLoaderErrorResponse)actualResult.getBody();
 
-        assertEquals(actualResult.getStatusCode(), HttpStatus.BAD_REQUEST);
+        assertEquals(HttpStatus.BAD_REQUEST, actualResult.getStatusCode());
         assert body != null;
-        assertEquals(body.getMessage(), FileLoaderResponseMessages.INCORRECT_REQUEST_TYPE.getMessage());
-        assertEquals(body.getCode(), FileLoaderResponseCodes.INCORRECT_REQUEST_TYPE.name());
+        assertEquals(FileLoaderResponseMessages.INCORRECT_REQUEST_TYPE.getMessage(), body.getMessage());
+        assertEquals(FileLoaderResponseCodes.INCORRECT_REQUEST_TYPE.name(), body.getCode());
     }
 
     @Test
@@ -67,10 +68,33 @@ public class FilesLoaderControllerTests {
         ResponseEntity<?> actualResult = filesLoaderController.handlePostFileParser(multipartFile);
         FilesLoaderErrorResponse body = (FilesLoaderErrorResponse)actualResult.getBody();
 
-        assertEquals(actualResult.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actualResult.getStatusCode());
         assert body != null;
-        assertEquals(body.getMessage(), FileLoaderResponseMessages.INTERNAL_SERVER_ERROR.getMessage());
-        assertEquals(body.getCode(), FileLoaderResponseCodes.INTERNAL_SERVER_ERROR.name());
+        assertEquals(FileLoaderResponseMessages.INTERNAL_SERVER_ERROR.getMessage(), body.getMessage());
+        assertEquals(FileLoaderResponseCodes.INTERNAL_SERVER_ERROR.name(), body.getCode());
+    }
+
+    @Test
+    @DisplayName(
+            "POST /api/v1/files/parser тестирует случай, " +
+            "когда HTTP статус BAD REQUEST и возвращается ошибка с кодом IncorrectEncoding"
+    )
+    void handlePostFileParser_returnsIncorrectEncoding() {
+        when(multipartFile.getContentType()).thenReturn(MediaType.TEXT_PLAIN_VALUE);
+
+        try {
+            when(multipartFile.getBytes()).thenThrow(new UnsupportedEncodingException("Incorrect encoding"));
+        } catch (IOException e) {
+            // just ignore
+        }
+
+        ResponseEntity<?> actualResult = filesLoaderController.handlePostFileParser(multipartFile);
+        FilesLoaderErrorResponse body = (FilesLoaderErrorResponse)actualResult.getBody();
+
+        assertEquals(HttpStatus.BAD_REQUEST, actualResult.getStatusCode());
+        assert body != null;
+        assertEquals(FileLoaderResponseMessages.INCORRECT_ENCODING.getMessage(), body.getMessage());
+        assertEquals(FileLoaderResponseCodes.INCORRECT_ENCODING.name(), body.getCode());
     }
 
     @Test
@@ -92,9 +116,9 @@ public class FilesLoaderControllerTests {
         ResponseEntity<?> actualResult = filesLoaderController.handlePostFileParser(multipartFile);
         FilesLoaderResponse body = (FilesLoaderResponse) actualResult.getBody();
 
-        assertEquals(actualResult.getStatusCode(), HttpStatus.OK);
+        assertEquals(HttpStatus.OK, actualResult.getStatusCode());
         assert body != null;
-        assertEquals(body.getCode(), FileLoaderResponseCodes.SUCCESS.name());
-        assertEquals(body.getData(), "test");
+        assertEquals(FileLoaderResponseCodes.SUCCESS.name(), body.getCode());
+        assertEquals("test", body.getData());
     }
 }


### PR DESCRIPTION
Сделал рефакторинг:
1. Сделал обработку ошибки UnsupportedEncodingException, когда не удалось преобразовать в нужную кодировку файл.
2. Дополнил логирование всех ошибок stack trace'ом, чтобы можно было отследить где конкретно произошло ошибка
3. Явно выделил момент создания строки на основе байтов в кодировке UTF-8
4. Убрал везде использование MessageFormat.format и поменял его на более удобный - String.format
5. Добавил тест сервиса и контроллера на случай возникновения UnsupportedEncodingException